### PR TITLE
support nitro based instances; volume mounting sligtly different

### DIFF
--- a/pkg/cloudprovider/providers/aws/device_allocator.go
+++ b/pkg/cloudprovider/providers/aws/device_allocator.go
@@ -93,6 +93,21 @@ func NewDeviceAllocator() DeviceAllocator {
 	}
 }
 
+// NewNVMeDeviceAllocator allocates device names according to scheme 1-26
+// it moves along the ring and always picks next device until device list is
+// exhausted.
+func NewNVMeDeviceAllocator() DeviceAllocator {
+	possibleDevices := make(map[mountDevice]int)
+	for i := 1; i <= 26; i++ {
+		dev := mountDevice([]rune{string(i)})
+		possibleDevices[dev] = 0
+	}
+	return &deviceAllocator{
+		possibleDevices: possibleDevices,
+		counter:         0,
+	}
+}
+
 // GetNext gets next available device from the pool, this function assumes that caller
 // holds the necessary lock on deviceAllocator
 func (d *deviceAllocator) GetNext(existingDevices ExistingDevices) (mountDevice, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
